### PR TITLE
HITとBLOWのカウントが反転する問題を解決[水野晴斗]

### DIFF
--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -140,9 +140,9 @@ class HitAndBlowGame:
             self.blow(split_i_num, split_c_num, result)
 
         for re in result:
-            if re == HitAndBlowGame.HitBlowResult.HIT:
-                blow += 1
             if re == HitAndBlowGame.HitBlowResult.BLOW:
+                blow += 1
+            if re == HitAndBlowGame.HitBlowResult.HIT:
                 hit += 1
 
         return hit, blow


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/Hit-and-Blow/issues/12

### 対応内容（何に取り組んだか）
HitとBlowのカウントが反転する問題を解決しました．

### 対応方法(どう対処したか具体的に)
HITとBLOＷをカウントする条件において，条件式が入れ替わっていたので元に戻した．

### レビューしてほしい点（工夫点など）
条件式が正しいかどうかの確認をお願いします．

***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x] レビューアをアサインしましたか（右上のReviewersにshoei03を設定してください）
- [x] 適切なラベルを付けましたか（右上のlabelに適切なラベルを設定して下さい）
- [x] 適切にコメントしていますか
