### PR TITLE
CPUの予想を強くするために過去のHit/Blow結果に基づいて正解の可能性がある予想を行う [水野晴斗]

### DIFF
--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -41,7 +41,6 @@ class HitAndBlowGame:
         for i in range(1000):
             if len(set(list(str(i)))) == 3:
                 self.cpu_candidates.append(str(i).zfill(3))
-    
 
     def game_start(self, event=None):
         """ゲームをスタート時に呼び出し"""
@@ -122,10 +121,10 @@ class HitAndBlowGame:
         for _ in range(3):
             val += str(random.randint(0, 9))
         return val
-    
+
     def cpu_input(self):
         return random.choice(self.cpu_candidates)
-    
+
     def change_cpu_candidate(self, prev_input, hit, blow):
         new_candidates = []
         for candidate in self.cpu_candidates:
@@ -133,7 +132,7 @@ class HitAndBlowGame:
             if h == hit and b == blow:
                 new_candidates.append(candidate)
         self.cpu_candidates = new_candidates
-            
+
     def simulate_judge(self, guess, answer):
         hit = 0
         blow = 0
@@ -152,11 +151,12 @@ class HitAndBlowGame:
                     break
 
         for r in result:
-            if r == self.HitBlowResult.HIT: hit += 1
-            elif r == self.HitBlowResult.BLOW: blow += 1
+            if r == self.HitBlowResult.HIT:
+                hit += 1
+            elif r == self.HitBlowResult.BLOW:
+                blow += 1
 
         return hit, blow
-
 
     def HB_judge(self, input_num):
         """入力した数字のHとBを返す

--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -118,10 +118,10 @@ class HitAndBlowGame:
         for _ in range(3):
             val += str(random.randint(0, 9))
         return val
-    
+
     def cpu_input(self):
         return random.choice(self.cpu_candidates)
-    
+
     def change_cpu_candidate(self, prev_input, hit, blow):
         new_candidates = []
         for candidate in self.cpu_candidates:
@@ -129,7 +129,7 @@ class HitAndBlowGame:
             if h == hit and b == blow:
                 new_candidates.append(candidate)
         self.cpu_candidates = new_candidates
-            
+
     def simulate_judge(self, guess, answer):
         hit = 0
         blow = 0
@@ -148,11 +148,12 @@ class HitAndBlowGame:
                     break
 
         for r in result:
-            if r == self.HitBlowResult.HIT: hit += 1
-            elif r == self.HitBlowResult.BLOW: blow += 1
+            if r == self.HitBlowResult.HIT:
+                hit += 1
+            elif r == self.HitBlowResult.BLOW:
+                blow += 1
 
         return hit, blow
-
 
     def HB_judge(self, input_num):
         """入力した数字のHとBを返す

--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -37,7 +37,11 @@ class HitAndBlowGame:
         self.shot_button.addEventListener("click", create_proxy(self.shot))
         self.highLow_button.addEventListener("click", create_proxy(self.highLow))
 
-        self.cpu_candidates = [str(i).zfill(3) for i in range(1000)]
+        self.cpu_candidates = []
+        for i in range(1000):
+            if len(set(list(str(i)))) == 3:
+                self.cpu_candidates.append(str(i).zfill(3))
+    
 
     def game_start(self, event=None):
         """ゲームをスタート時に呼び出し"""
@@ -118,10 +122,10 @@ class HitAndBlowGame:
         for _ in range(3):
             val += str(random.randint(0, 9))
         return val
-
+    
     def cpu_input(self):
         return random.choice(self.cpu_candidates)
-
+    
     def change_cpu_candidate(self, prev_input, hit, blow):
         new_candidates = []
         for candidate in self.cpu_candidates:
@@ -129,7 +133,7 @@ class HitAndBlowGame:
             if h == hit and b == blow:
                 new_candidates.append(candidate)
         self.cpu_candidates = new_candidates
-
+            
     def simulate_judge(self, guess, answer):
         hit = 0
         blow = 0
@@ -148,12 +152,11 @@ class HitAndBlowGame:
                     break
 
         for r in result:
-            if r == self.HitBlowResult.HIT:
-                hit += 1
-            elif r == self.HitBlowResult.BLOW:
-                blow += 1
+            if r == self.HitBlowResult.HIT: hit += 1
+            elif r == self.HitBlowResult.BLOW: blow += 1
 
         return hit, blow
+
 
     def HB_judge(self, input_num):
         """入力した数字のHとBを返す

--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -37,6 +37,8 @@ class HitAndBlowGame:
         self.shot_button.addEventListener("click", create_proxy(self.shot))
         self.highLow_button.addEventListener("click", create_proxy(self.highLow))
 
+        self.cpu_candidates = [str(i).zfill(3) for i in range(1000)]
+
     def game_start(self, event=None):
         """ゲームをスタート時に呼び出し"""
         if event:
@@ -47,7 +49,7 @@ class HitAndBlowGame:
         self.set_player_num()
         self.result.innerText = ""
         self.turn = 1
-        self.cpu_num = self.cpu_input()
+        self.cpu_num = self.cpu_first_input()
         self.is_game_continue = True
         print(f"自分の数字: {self.player_num}")
         print(f"cpuの数字: {self.cpu_num}")
@@ -88,6 +90,7 @@ class HitAndBlowGame:
 
         # cpuが入力した数字のHit数とBLow数を判定
         c_hit, c_blow = self.HB_judge(cpu_input)
+        self.change_cpu_candidate(cpu_input, c_hit, c_blow)
 
         # CPUの入力とHit数とBLow数をテーブルに追加
         new_row = self.a.insertRow(-1)
@@ -107,7 +110,7 @@ class HitAndBlowGame:
                 self.result.innerText = "You Lose!"
             self.disable_input_form()  # これ以上入力させないために、フォームを無効にする
 
-    def cpu_input(self):
+    def cpu_first_input(self):
         """ランダムに3桁の数字を返す"""
         val = ""
 
@@ -115,6 +118,41 @@ class HitAndBlowGame:
         for _ in range(3):
             val += str(random.randint(0, 9))
         return val
+    
+    def cpu_input(self):
+        return random.choice(self.cpu_candidates)
+    
+    def change_cpu_candidate(self, prev_input, hit, blow):
+        new_candidates = []
+        for candidate in self.cpu_candidates:
+            h, b = self.simulate_judge(str(prev_input), str(candidate))
+            if h == hit and b == blow:
+                new_candidates.append(candidate)
+        self.cpu_candidates = new_candidates
+            
+    def simulate_judge(self, guess, answer):
+        hit = 0
+        blow = 0
+        result = [self.HitBlowResult.NONE] * 3
+
+        for i in range(3):
+            if guess[i] == answer[i]:
+                result[i] = self.HitBlowResult.HIT
+
+        for i in range(3):
+            if result[i] == self.HitBlowResult.HIT:
+                continue
+            for j in range(3):
+                if guess[i] == answer[j] and result[j] == self.HitBlowResult.NONE:
+                    result[j] = self.HitBlowResult.BLOW
+                    break
+
+        for r in result:
+            if r == self.HitBlowResult.HIT: hit += 1
+            elif r == self.HitBlowResult.BLOW: blow += 1
+
+        return hit, blow
+
 
     def HB_judge(self, input_num):
         """入力した数字のHとBを返す
@@ -140,9 +178,9 @@ class HitAndBlowGame:
             self.blow(split_i_num, split_c_num, result)
 
         for re in result:
-            if re == HitAndBlowGame.HitBlowResult.HIT:
-                blow += 1
             if re == HitAndBlowGame.HitBlowResult.BLOW:
+                blow += 1
+            if re == HitAndBlowGame.HitBlowResult.HIT:
                 hit += 1
 
         return hit, blow


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/Hit-and-Blow/issues/18

### 対応内容（何に取り組んだか）
Hit/Blow数と予想から，正解する可能性のない数値を予想しないようにプログラムを変更した．

### 対応方法(どう対処したか具体的に)
正解する可能性のある数値のみを管理するself.cpu_candidates配列を用意する．
予想が行われるたび，そのターンに行った予測とself.cpu_candidates配列の各要素と比較をし，正解する可能性のある数値のみを取得する．
正解する可能性のある数値のみを配列にし，self.cpu_candidatesに上書きをする．

### レビューしてほしい点（工夫点など）
CPUの予想手法が誤っていないか．
誤って正解する可能性のない数値が配列に含まれていないか．

***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x] レビューアをアサインしましたか（右上のReviewersにshoei03を設定してください）
- [x] 適切なラベルを付けましたか（右上のlabelに適切なラベルを設定して下さい）
- [x] 適切にコメントしていますか
