### PR TITLE
HitBlowResultの変更によるhitとblowとそれ以外であることを正しく表示[中出侑吾]

### DIFF
--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -8,9 +8,9 @@ from pyodide.ffi import create_proxy
 
 class HitAndBlowGame:
     class HitBlowResult(Enum):
-        HIT = auto()
-        BLOW = auto()
-        NONE = auto()
+        HIT = 1
+        BLOW = 1
+        NONE = 0
 
     def __init__(self):
         """初期化処理"""
@@ -163,7 +163,7 @@ class HitAndBlowGame:
         """
         for i in range(3):
             if split_num[i] == split_i_num[i]:
-                result[i] = HitAndBlowGame.HitBlowResult.HIT
+                result[i] = result[i] + HitAndBlowGame.HitBlowResult.HIT
 
     def blow(self, split_i_num, split_num, result):
         """ブローしているかの判定
@@ -182,7 +182,7 @@ class HitAndBlowGame:
                 if j in used_indices:
                     continue
                 if split_num[i] == split_i_num[j]:
-                    result[i] = HitAndBlowGame.HitBlowResult.BLOW
+                    result[i] = result[i] + HitAndBlowGame.HitBlowResult.BLOW
                     used_indices.append(j)
 
     def clear_table(self):

--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -8,7 +8,7 @@ from pyodide.ffi import create_proxy
 
 class HitAndBlowGame:
     class HitBlowResult(Enum):
-        HIT = 1
+        HIT = 2
         BLOW = 1
         NONE = 0
 
@@ -163,7 +163,7 @@ class HitAndBlowGame:
         """
         for i in range(3):
             if split_num[i] == split_i_num[i]:
-                result[i] = result[i] + HitAndBlowGame.HitBlowResult.HIT
+                result[i] = HitAndBlowGame.HitBlowResult.HIT
 
     def blow(self, split_i_num, split_num, result):
         """ブローしているかの判定
@@ -182,7 +182,7 @@ class HitAndBlowGame:
                 if j in used_indices:
                     continue
                 if split_num[i] == split_i_num[j]:
-                    result[i] = result[i] + HitAndBlowGame.HitBlowResult.BLOW
+                    result[i] = HitAndBlowGame.HitBlowResult.BLOW
                     used_indices.append(j)
 
     def clear_table(self):


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/Hit-and-Blow/issues/19

### 対応内容（何に取り組んだか）
hit and blowの結果を格納するべきクラス、HitBlowResultの中身をきちんと結果を格納するように変更した。

### 対応方法(どう対処したか具体的に)
HITとBLOWとそれ以外（NONE）であるという状態をresult（HitBlowResultに直接かかわる配列、ユーザが入力した3桁の数字がそれぞれHITかBLOWかNONEだったかを保持する配列）に格納するようにした。

### レビューしてほしい点（工夫点など）
このクラスが使われている関数は、関数hit, blow, HB_judgeのみであった。
hitでは結果とプレイヤーが入力した数字とを比べるのだが、その時に位置まで一致しているかを確認し、
result[i] = HitAndBlowGame.HitBlowResult.HITを実行していた。
blowでは、HIT対象を除外し、場所は合っていないが数字は合っているものだけを抜粋し、
result[i] = HitAndBlowGame.HitBlowResult.blowを実行していた。
おそらく、これらのことから、resultは3桁の数字の場所ごとにHITとBLOWとそれ以外であることの状態を保持するものだと考えた。例えば、答えが123で入力が134である場合、resultには[{HIT}, {BLOW}, {NONE}]を保持する。
そのため、状態を変えるだけであるから単純な０，１，２を状態の種類として管理した。
***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x] レビューアをアサインしましたか（右上のReviewersにshoei03を設定してください）
- [x] 適切なラベルを付けましたか（右上のlabelに適切なラベルを設定して下さい）
- [x] 適切にコメントしていますか
