### PR TITLE
画面下部に数値メモを表示して，ユーザが数値メモできるように変更 [水野晴斗]

### DIFF
--- a/assets/css/examples.css
+++ b/assets/css/examples.css
@@ -64,3 +64,35 @@ th {
   background-color: gray;
   color: white;
 }
+
+.memo{
+  display: flex;
+}
+
+.memo-num {
+  position: relative;
+  height: 50px;
+  width: 50px;
+  font-size: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: solid 2px black;
+  font-weight: bold;
+}
+
+.memo-num .cross {
+  position: absolute;
+  font-size: 40px;
+  color: red;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.memo-num .circle {
+  position: absolute;
+  font-size: 40px;
+  color: blue;
+  pointer-events: none;
+  opacity: 0;
+}

--- a/index.html
+++ b/index.html
@@ -70,6 +70,37 @@
     </table>
     <br>
     <button class="btn btn-border" id="newGameBtn">New Game</button>
+
+    <div class="memo">
+        <div class="memo-num">0<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">1<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">2<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">3<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">4<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">5<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">6<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">7<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">8<div class="cross">×</div><div class="circle">○</div></div>
+        <div class="memo-num">9<div class="cross">×</div><div class="circle">○</div></div>
+    </div>
 </body>
+<script>
+    document.querySelectorAll('.memo-num').forEach(num => {
+        num.addEventListener('click', () => {
+            const cross = num.querySelector('.cross');
+            const circle = num.querySelector('.circle');
+            if (cross.style.opacity === '1') {
+                circle.style.opacity = '0';
+                cross.style.opacity = '0';
+            } else if (circle.style.opacity === '1') {
+                circle.style.opacity = '0';
+                cross.style.opacity = '1';
+            } else {
+                circle.style.opacity = '1';
+                cross.style.opacity = '0';
+            }
+        });
+    });
+</script>
 
 </html>


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/Hit-and-Blow/issues/29

### 対応内容（何に取り組んだか）
画面下部に数値メモを設置し，クリックでメモを編集できるように変更した．

### 対応方法(どう対処したか具体的に)
index.htmlを編集し，数値メモの設置を行い，JavaScriptで〇や×の表示を行えるようにした．
また，assets/css/examples.cssを編集し，設置した数値メモのデザインを整えた．

### レビューしてほしい点（工夫点など）
数値メモの配置が適切かどうか．
クリックをしたときに数値メモが正しく動作するか．

***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x] レビューアをアサインしましたか（右上のReviewersにshoei03を設定してください）
- [x] 適切なラベルを付けましたか（右上のlabelに適切なラベルを設定して下さい）
- [x] 適切にコメントしていますか
