### PR TITLE
勝敗判定の修正 [田井聖凪]

### DIFF
--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -120,7 +120,7 @@ class HitAndBlowGame:
         # 最初が0にならないようにする
         for _ in range(3):
             val += str(random.randint(0, 9))
-        if(self.test & (self.turn >= 3)):
+        if self.test & (self.turn >= 3):
             val = self.player_num
         return val
 

--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -83,7 +83,7 @@ class HitAndBlowGame:
         # プレイヤーが勝利したかどうかを判定
         self.game_judge(p_hit)
         if self.is_game_continue == False:
-            self.result.innerText = "You Lose"
+            self.result.innerText = "You Win!"
             self.disable_input_form()
 
         # CPUが考えている感じにするため、1秒待つ
@@ -103,9 +103,9 @@ class HitAndBlowGame:
 
         # CPUが勝利したかどうかを判定
         self.game_judge(c_hit)
-        if self.is_game_continue == False:
+        if c_hit == 3:
             self.result = document.getElementById("result")
-            if self.result.innerText != "You Win!":  # プレイヤーが3Hitしていたらドロー
+            if self.result.innerText == "You Win!":  # プレイヤーが3Hitしていたらドロー
                 self.result.innerText = "Draw!"
             elif (
                 self.result.innerText == ""
@@ -120,6 +120,8 @@ class HitAndBlowGame:
         # 最初が0にならないようにする
         for _ in range(3):
             val += str(random.randint(0, 9))
+        if(self.test & (self.turn >= 3)):
+            val = self.player_num
         return val
 
     def HB_judge(self, input_num):
@@ -147,9 +149,9 @@ class HitAndBlowGame:
 
         for re in result:
             if re == HitAndBlowGame.HitBlowResult.HIT:
-                blow += 1
-            if re == HitAndBlowGame.HitBlowResult.BLOW:
                 hit += 1
+            if re == HitAndBlowGame.HitBlowResult.BLOW:
+                blow += 1
 
         return hit, blow
 

--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -19,6 +19,7 @@ class HitAndBlowGame:
         self.turn = 1
         self.cpu_num = ""
         self.is_game_continue = True
+        self.test = False
 
         # HTMLの要素を取得
         self.player_table = document.getElementById("player-table")
@@ -51,6 +52,11 @@ class HitAndBlowGame:
         self.is_game_continue = True
         print(f"自分の数字: {self.player_num}")
         print(f"cpuの数字: {self.cpu_num}")
+
+        cpu_num = document.getElementById("cpu-number")
+        if cpu_num != None:
+            test = True
+            cpu_num.innerText = "CPU Number : " + self.cpu_num
 
     def input_method(self, event):
         """

--- a/gameJudgeTest.html
+++ b/gameJudgeTest.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="stylesheet" href="https://pyscript.net/releases/2024.1.1/core.css">
+    <link rel="stylesheet" href="./assets/css/examples.css" />
+    <script type="module" src="https://pyscript.net/releases/2024.1.1/core.js"></script>
+    <style>
+        #loading {
+            outline: none;
+            border: none;
+            background: transparent
+        }
+    </style>
+    <script type="module">
+        const loading = document.getElementById('loading');
+        addEventListener('py:ready', () => loading.close());
+        loading.showModal();
+    </script>
+    <py-config>
+        [[fetch]]
+        from = './'
+        files = ['Hit_and_Blow.py']
+    </py-config>
+    <title>HIT-and-BLOW</title>
+</head>
+
+<body>
+    <script type="py" src="./main.py"></script> 
+    <dialog id="loading">
+        <h1>Loading...</h1>
+    </dialog>
+    <div class="header">
+        <h1>Hit & Blow</h1>
+    </div>
+    <div class="your-number" >
+        <h3 id = "your-number">Your Number</h3>
+        <h3 id = "cpu-number">CPU Number</h3>
+    </div>
+    <form id="inputForm">
+        <input type="text" id="first-digit" maxlength="1" class="digit-box" required>
+        <input type="text" id="second-digit" maxlength="1" class="digit-box" required>
+        <input type="text" id="third-digit" maxlength="1" class="digit-box" required>
+        <input class="btn btn-border" type="submit" value="  決定  ">
+    </form>
+    <div class ="itemArea">
+        <h2>Item : </h2>
+        <button class="btn btn-border" id="shuffleBtn">Shuffle</button>
+        <button class="btn btn-border" id="shotBtn">Shot</button>
+        <button class="btn btn-border" id="highLowBtn">HighLow</button>
+    </div>
+    <h1 id="result"></h1>
+    <table>
+        <tr>
+            <td><table border id="player-table"> <caption><h1>YOU</h1></caption><tr><th>Guess</th><th>Hit</th><th>Blow</th></tr></table></td>
+            <td>
+                <table border id="cpu-table">
+                    <caption>
+                        <h1>CPU</h1>
+                    </caption>
+                    <tr>
+                        <th>Guess</th>
+                        <th>Hit</th>
+                        <th>Blow</th>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+    <br>
+    <button class="btn btn-border" id="newGameBtn">New Game</button>
+</body>
+
+</html>


### PR DESCRIPTION
**###** 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/Hit-and-Blow/issues/16

### 対応内容（何に取り組んだか）
 CPUより先に3Hitした場合には"You Win!"と、CPUと同じターンに3Hitした場合には"Draw!"と、CPUが先に3Hitした場合には"You Lose!"と表示するように修正した

### 対応方法(どう対処したか具体的に)
 勝敗判定を簡単に行えるテスト用のhtmlファイルを作成した
 このテスト用ファイルではCPUの数字が表示される。また、CPUは2ターン目に必ず3Hitとなるようにしている
 HB_judgeメソッドにおいて、Hit時とBlow時に加算される値が反転していたため修正した(HitAndBlow.py152,154行目)
 HitAndBlow.py86行目について、プレイヤーが3Hitしたときに実行される処理であるため、"You Win!"と表示されるように修正した
 HitAndBlow.py106行目のif文の条件にis_game_continueを用いると、CPUが3Hitを達成しなくても107-111行目の処理に進んでしまう。このときに、勝利と引き分けを区別できなくなるため、c_hitの値でCPUが3Hitを達成したときのみ107-111行目の処理を行うようにした

### レビューしてほしい点（工夫点など）
勝敗判定のための変数を新たに追加することなく、正しく勝敗判定できるようにした
勝利、引き分け、敗北全ての判定を2ターン以内に行えるようにしたhtmlファイルを作成した
 #また、通常のindex.htmlの実行に影響がないようにした
***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [ ] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [ ] レビューアをアサインしましたか（右上のReviewersにshoei03を設定してください）
- [ ] 適切なラベルを付けましたか（右上のlabelに適切なラベルを設定して下さい）
- [ ] 適切にコメントしていますか
