### PR TITLE
すべて異なる数字の数字列のみ登録できるように修正[徳元聖也]

### DIFF
--- a/Hit_and_Blow.py
+++ b/Hit_and_Blow.py
@@ -221,8 +221,21 @@ class HitAndBlowGame:
     def set_player_num(self):
         """プレイヤーの数字を設定する"""
         # 3桁の数字を入力するまでループ
-        self.player_num = prompt("3桁の数字を入力してください")
-        your_num = document.getElementById("your-number")
+        # すべて異なる数字の数字列のみ登録できるように修正
+        while(True):
+            self.player_num = prompt("3桁の数字を入力してください")
+            your_num = document.getElementById("your-number")
+            player_num_int = int(self.player_num)
+            digit1 = player_num_int % 10
+            digit10 = (player_num_int % 100) // 10
+            digit100 = player_num_int // 100
+            
+            if((digit1 == digit10) or (digit10 == digit100) or (digit100 == digit1)):
+                alert("3桁はすべて異なる数字を入力してください。")
+                continue
+            else:
+                break
+            
         your_num.innerText = "Your Number : " + self.player_num
 
     def shuffle(self, event=None):


### PR DESCRIPTION
### 対応したissueのURL 
https://github.com/SocSEL-INFOseminar1-2025/Hit-and-Blow/issues/28

### 対応内容（何に取り組んだか）
すべて異なる数字の数字列のみ登録できるように修正

### 対応方法(どう対処したか具体的に)
登録する文字の100の桁の数字、10の桁の数字、1の桁の数字を得て、3つ中1つでも同じなら再入力を求めるようにした。

### レビューしてほしい点（工夫点など）
数字の摘出を頑張りました。

***

## 最終チェックリスト(xでチェックが入ります)
- [x] 対応するissueのリンクは貼りましたか
- [x] 適切なタイトルをつけましたか（対応内容[対応者名]）
- [x] レビューアをアサインしましたか（右上のReviewersにshoei03を設定してください）
- [x] 適切なラベルを付けましたか（右上のlabelに適切なラベルを設定して下さい）
- [x] 適切にコメントしていますか
